### PR TITLE
improv/large_file_message_received_error

### DIFF
--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -189,6 +189,7 @@ model MessageUpdate {
   participant String?  @db.VarChar(100)
   pollUpdates Json?    @db.Json
   status      String   @db.VarChar(30)
+  errors      Json?    @db.Json
   Message     Message  @relation(fields: [messageId], references: [id], onDelete: Cascade)
   messageId   String
   Instance    Instance @relation(fields: [instanceId], references: [id], onDelete: Cascade)

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -188,6 +188,7 @@ model MessageUpdate {
   participant String?  @db.VarChar(100)
   pollUpdates Json?    @db.JsonB
   status      String   @db.VarChar(30)
+  errors      Json?    @db.JsonB
   Message     Message  @relation(fields: [messageId], references: [id], onDelete: Cascade)
   messageId   String
   Instance    Instance @relation(fields: [instanceId], references: [id], onDelete: Cascade)

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -836,7 +836,18 @@ export class BusinessStartupService extends ChannelStartupService {
             });
 
             if (!findMessage) {
-              return;
+              if (item.errors?.length) {
+                this.sendDataWebhook(Events.MESSAGES_UPDATE, {
+                  keyId: key.id,
+                  remoteJid: key.remoteJid,
+                  fromMe: key.fromMe,
+                  participant: key?.remoteJid,
+                  status: item.status.toUpperCase(),
+                  errors: item.errors,
+                  instanceId: this.instanceId,
+                });
+              }
+              continue;
             }
 
             if (item.message === null && item.status === undefined) {
@@ -874,6 +885,7 @@ export class BusinessStartupService extends ChannelStartupService {
               fromMe: key.fromMe,
               participant: key?.remoteJid,
               status: item.status.toUpperCase(),
+              errors: item.errors?.length ? item.errors : undefined,
               instanceId: this.instanceId,
             };
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3092,7 +3092,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
           const response = await axios.get(mediaMessage.media, config);
 
-          mimetype = response.headers['content-type'];
+          mimetype = response.headers['content-type'] as string;
         }
       }
 

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1204,7 +1204,7 @@ export class ChatwootService {
         const response = await axios.get(media, {
           responseType: 'arraybuffer',
         });
-        mimeType = response.headers['content-type'];
+        mimeType = response.headers['content-type'] as string;
       }
 
       let type = 'document';
@@ -2214,7 +2214,7 @@ export class ChatwootService {
         if (isAdsMessage) {
           const imgBuffer = await axios.get(adsMessage.thumbnailUrl, { responseType: 'arraybuffer' });
 
-          const extension = mimeTypes.extension(imgBuffer.headers['content-type']);
+          const extension = mimeTypes.extension(imgBuffer.headers['content-type'] as string);
           const mimeType = extension && mimeTypes.lookup(extension);
 
           if (!mimeType) {


### PR DESCRIPTION
[ALTERAÇÃO REALIZADA]
Melhorada recepção de webhooks, para sincronizar eventos de mensagens que não puderam ser sincronizadas devido a algum erro que impediu a entrega da mensagem pela meta.

[ROTINA]
Recepção de mensagens de conexões oficiais (Business API)

[ORIENTAÇÃO DE TESTES]

1. Conectar uma instancia Business API
2. Enviar um arquivo grande de vídeo (Maior que 100mb)
3. Receber um webhook de erro e que o mesmo seja repassado para os locais conectados a instância.